### PR TITLE
Make traefik starts with ContentType auto detect to false 

### DIFF
--- a/apps/api/src/lib/common.ts
+++ b/apps/api/src/lib/common.ts
@@ -727,6 +727,7 @@ export async function startTraefikProxy(id: string): Promise<void> {
 			--certificatesresolvers.letsencrypt.acme.httpchallenge=true \
 			--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme/acme.json \
 			--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web \
+			--label=traefik.http.middlewares.autodetect.contenttype.autodetect=false
 			--log.level=error`
 		});
 		await prisma.destinationDocker.update({


### PR DESCRIPTION
Reason: If on the same port there is a multiplexer that support many protocols and infer them from the content-type passed from the client, with then mess up with traefik auto detection feature